### PR TITLE
Update organization docs for consistent language

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ There is a Women Who Code national organization github - so generic resources li
 #### DC Network
 
 * [WWC DC Slack Guide](https://github.com/womenwhocodedc/organization/blob/master/slack_guide.md)
-* [WWC DC New Events Guide](https://github.com/womenwhocodedc/organization/blob/master/new_events.md)
-
+* [WWC DC Language Lab Guide](https://github.com/womenwhocodedc/organization/blob/master/language_lab_guide.md)
+* [WWC DC Event Ideas](https://github.com/womenwhocodedc/organization/blob/master/event_ideas.md)

--- a/event_ideas.md
+++ b/event_ideas.md
@@ -4,14 +4,12 @@ We have compiled a list of the most popular events that we have heard about and 
 
 If you are interested in helping or have an idea for something new that you think we should add, shoot an email to <WWCodeDC@gmail.com>!
 
-### Study Groups
+### Language Labs
 
-* Algorithms & Interview Prep
-	* Practice various types of algorithms and interview each other
-* Python
-	* Learn python as it relates to web development and/or big data
 * iOS
 	* Learn Objective-C, and Swift as it applies to mobile development
+* Java
+	* We have a joint Java/Android group, but perhaps a distinct Java group that's not Android focused?
 
 ### Sessions
 
@@ -26,7 +24,7 @@ What dev ops wish developers knew / intro training for current programmers
 * Using "X" API
 	* Session walking through a certain API or data set
 * Intro to Programming
-	* Basics of programming for people that our new
+	* Basics of programming for people that are new
 
 
 

--- a/language_lab_guide.md
+++ b/language_lab_guide.md
@@ -1,18 +1,16 @@
-### Study Groups & Hack Nights
+### Language Labs
 
-Here is some information around what we look for in recurring study groups or hack nights. The main pieces that we look for before starting a group are:
+Here is some information around what we look for in recurring language labs. The main pieces that we look for before starting a group are:
 
 * Interest in the topic/space
 * 2 Leads that can dedicate time to going every week (or at least relatively often)
 * Hosts for the events
 
-Getting all of these things in place takes some time. So as long as you are interested in the study group and will be for a fair bit of time - reach out to us at <WWCodeDC@gmail.com> about where we stand regarding the group!  
+Getting all of these things in place takes some time. So as long as you are interested in the language group and will be for a fair bit of time - reach out to us at <WWCodeDC@gmail.com> about where we stand regarding the group!  
 
-Anyway, if you aren't sure what the difference is between a study group and a hack night - the main piece is that a study group is for following a certain book/online course/something with weekly "assignments" so to speak. A hack night is more free form where people could work on open source projects or personal development that they want to get done!  
+Recurring language meetups can take many forms. One week might be a tech talk from a member of the group (e.g. a talk on Ruby fundamentals for Ruby on Rails). Another week could be a code along of a tutorial (e.g. following along together as you go through the Android _Building Your First App_ guide). A hack night is more free form where people could work on open source projects or personal development that they want to get done. There are many more ideas listed in our [Suggested Meeting Types](https://github.com/womenwhocodedc/organization/blob/master/leadership-resources/Education/suggested-meeting-types.md). This list isn't exhaustive so feel free to suggest topics as well.  
 
-*Currently we are experimenting with splitting our weekly sessions into two groups - one that is focused on "hack nights" and the other that follows a "learning plan." We will update as we learn!*
-
-#### Hack / Work Nights
+#### Hack Night Ideas
 
 * Language specific or agnostic
 * Free for all to work on whatever projects / tools they desire
@@ -20,21 +18,22 @@ Anyway, if you aren't sure what the difference is between a study group and a ha
 * Promote members working together to build an app/website/hack for X
 * Less structured, “mentors” may float around if in attendance
 
-#### Study Groups
+#### Language Lab Ideas
 
-* Should have some sort of plan for the duration of the study group 
+* Should have some sort of plan for the duration of the meetup, or meetups if planned to split over multiple sessions
 	* coursera class
 	* book to follow
+	* tech talk
 	* free online lectures (with problem sets)
 	* Leader could create a lesson plan, but that would require more commitment and understanding of what they want to go over
 * Have an leader that is dedicated to going through all of the materials
-* Set a timeline for the group (9 weeks of python, 12 weeks of interview prep, etc)
+* Set a timeline for the group if split over multiple sessions (4 weeks Rails, 3 weeks of a Python project, etc.)
 	* Members can join late or come in and out
 	* Awesome opportunity for someone to document their work throughout the course so that if people come late they can use that as a resource!
 	* At the start of a new group, it could be beneficial to schedule out everything that you will learn so people can follow along. And then after one round you will have a group of people that all know the materials and can help those that join later.
 * Promote communication, collaboration, and camaraderie between group members
-* Promote that study group members attend larger DC tech events relevant to their work
-	* JS Study group goes to DC JS meetups, Java to DC Java, etc    
+* Promote that group members attend larger DC tech events relevant to their work
+	* Front end group goes to DC JS meetups, Java to DC Java, etc.    
 * **Examples**
 	* Follow the coursera course [Intro to Python](https://www.coursera.org/course/interactivepython)
 	* Go through the book [Cracking the Coding Interview (Java)](http://www.amazon.com/Cracking-Coding-Interview-Programming-Questions/dp/098478280X)

--- a/leadership-resources/Education/Front-End/README.md
+++ b/leadership-resources/Education/Front-End/README.md
@@ -1,16 +1,14 @@
-# Women Who Code D.C. Front-end Hacknight 
+# Women Who Code D.C. Front-End Lab
 
 ## Leads:
-* Alex Ulsh
 * Isatu Conteh
 * Emelia Kubo Kirschenbaum
-* Sarah Kleinman
 
-## Meet-up Night: Monday's every week
+## Meet-up Night: Mondays every week
 
 ## Meeting Locations:
 * ECMC - 1015 7th Street NW, Washington D.C. 20001 (Mt.Vernon/Convention Center)
 * Socrata - 1150 17th Street NW, Washington D.C. 20036 (Farragut West)
 * RepEquity - 1211 Conneticut Ave. NW Washington D.C. 20036 (Farragut North)
 * iSL (iStrategyLabs) - 641 S Street NW, Washington D.C. 20001 (Shaw)
-* Social Tables - 700 6th Street NW, Washington D.C. 20004 (Chinatown)
+* Social Tables - 1325 G St., NW, 3rd Floor, Washington, DC‎ (Metro Center)

--- a/leadership-resources/Education/Python/README.md
+++ b/leadership-resources/Education/Python/README.md
@@ -75,8 +75,7 @@ If needed put someone at the entrance to let people in
 
 
 ### Roster
-- [Anissa Jones]()
-- [Clara Bennett]()
-- [Jennifer Stark]()
-- [Jamie Johnson]()
-- [Mariella Paulino]() 
+- [Violet]()
+- [Tammy]()
+- [Maya]()
+- [Niki]()

--- a/leadership-resources/becoming_a_leader.md
+++ b/leadership-resources/becoming_a_leader.md
@@ -10,6 +10,6 @@ Next steps in getting involed are:
 - Read through our [Leadership Roles and Responsibilities]() to get an idea of what you're thinking of signing up for.
 
 ##### Probably:
-- Contact our Director of [Education]() or [Networking]() and say hi
+- Contact our Director of [Education](kdmcclin@gmail.com) or [Networking]() and say hi
 - Tweet at us @WomenWhoCodeDC
-- Ask in on Slack (womenwhocodedc.slack.com) for access to the Leadership Channels that you're interested in.
+- Ask in our Slack (womenwhocodedc.slack.com) for access to the Leadership Channels that you're interested in. If you're not in our Slack, [sign up](bit.ly/wwcdcslack)

--- a/leadership-resources/leadership_overview.md
+++ b/leadership-resources/leadership_overview.md
@@ -13,7 +13,7 @@ Being active on Slack is our second priority. Welcoming newcomers, encouraging c
 
 We expect leads on every team to attend at least 2 public Women Who Code DC Meetups a month (going to tons of leadership meetings doesn't count!) The purpose is for you to be visible and engaged in the community, you don't have to *lead* the meetup, or even understand/work on the topic at hand. A lot of us find these Meetups a good time to put an hour into WWC-related work. 
 
-Our leadership team is filled with productive and powerful peolpe. It's to be expected that some of us will get bogged down with our paid work, other things in life, etc. so please let your teammates know when you need to step back from your responsibilities for a while so we can plan and adjust. 
+Our leadership team is filled with productive and powerful people. It's to be expected that some of us will get bogged down with our paid work, other things in life, etc. so please let your teammates know when you need to step back from your responsibilities for a while so we can plan and adjust. 
 
 We start our relationship with leads by holding an introductory of Evaluation Period. **The Evaluation Period is designed for the new lead to evaluate the position and team and decide of they want to pursue a leadership role.** During this time, whoever recruited the new lead will guide her through the expectations of being a lead. **New leads and their Mentor will be responsible each week for coordinating on Slack to find 2 volunteers for the coming meetups, and to ensure the Meetup.com event is created and ready to happen.**
 
@@ -30,26 +30,26 @@ Directors: We have a separate page for [Directors Roles & Responsibilities], but
 _Detailed role descriptions can be found at the [Education Lead Roles & Responsibilities]() page._
 
 #### Roles
-- Director: [Emma Grasmeder]()
+- Director: [Katherine McClintic](http://www.katherine.tech/)
 - Algorithm Team:
   - [Amy Ghate]()
 - Front End:
-  - [Alex Ulsh]()
   - [Isa]()
-  - [Sarah]()
+  - [Emilia]()
 - Android:
-  - [Malynda]()
-  - [Tegan]()
+  - [Ijeoma]()
+  - [Radha]()
+  - [Lyndsey]()
 - Python:
-  - [Clara Bennett]()
-  - [Tammy Barbee]()
-  - [Anissa Johnson]()
-  - [Jamie Johnson]()
+  - [Tammy]()
+  - [Violet]()
+  - [Niki]()
+  - [Maya]()
 - Ruby:
-  - [Katherine McClintoc]()
-  - [Liz]()
-  - [Lauren]()
   - [Zuri]()
+  - [Erin]()
+  - [Nyasha]()
+  - [Mary Katherine]()
 
 ### Networking Team
 The networking team is responsible for maintaining and promoting the Women Who Code image and presence in Washington DC and beyond. It seeks to constantly improve WWC events and provide value for our members
@@ -65,20 +65,17 @@ Detailed role descriptions can be found at the [Network Development Leads Roles 
   - [Anne]()
 - Mentoring Managers: 
   - [Natassja]()
-  - [Zuri]()
   - [Pam]()
 - Entrepreneurial Events Manager:
-  - [Veni]()
-  - [Liz]()
+  - [Evan]()
 - Technical Events Manager: [Contact us to help fill the position!]()
 
 ### Technology Team
 The technology team is focused on the technical and backend aspects of the Women Who Code DC organization. Members of this team research or develop apps or technologies that can make our meetings run more smoothly or our members more marketable. The technology team is also at the forefront of recruiting and streamlining any technical talks.
 Detailed project and role descriptions can be found on the [Technology Development Projects & Responsibilities]() guide
 #### Roles
-- Director: [Nupur]()
+- Director: [Pam]()
 - www.womenwhocode.com development: 
-  - [Nupur]()
   - [Pam]()
 - www.dcfemtech.github.io development:
-  - [Contact us here to get involved!]()
+  - [Contact us here to get involved!](WWCodeDC@gmail.com)

--- a/learning-resources/dev_bootcamps.md
+++ b/learning-resources/dev_bootcamps.md
@@ -1,8 +1,9 @@
 ## Dev Bootcamps
 
 #### Dev Bootcamp
-* campuses in San Francisco, Chicago, New York City (more campuses opening soon)
-* full-stack Ruby/Rails at all locations (possibly diversifying soon)
+* campuses in San Francisco, Chicago, New York City, Seattle, Austin, San Diego, DC
+	*[location info](http://devbootcamp.com/locations/)
+* full-stack Ruby/Rails at all locations (many developers get jobs in other languages and frameworks)
 * female alumni you can contact with questions: [Katherine McClintic](kdmcclin@gmail.com)
 
 #### General Assembly

--- a/learning-resources/git_guide.md
+++ b/learning-resources/git_guide.md
@@ -1,6 +1,6 @@
 ### Git Guide for Updating WWC DC Resources
 
-In it's current state, this guide assumes that you have experience using Git and making changes to files / pushing to one of your own repos. In future versions we'll add ways to learn these skils, but for now - check out [Try Git](https://try.github.io).
+In its current state, this guide assumes that you have experience using Git and making changes to files / pushing to one of your own repos. In future versions we'll add ways to learn these skils, but for now - check out [Try Git](https://try.github.io).
 
 So if you are good with making changes to your own repo - how do you go about making changes to *this* repo?
 
@@ -17,7 +17,7 @@ So if you are good with making changes to your own repo - how do you go about ma
 	* Once you have made the changes, you will use `git add` and `git commit` as usual until `git status` shows the changes that you want to add.
 	* Finally you will type in `git push -u origin master`. This will move your changes up to your personal repo, which you can then go to GitHub to view.
 * Initiating a Pull Request
-	* GitHub's documentation is pretty terrible for this. All you have to do is navigate to your repo that has the changes in it, select the "Pull Request" button and you can add the name/	comments about your changes there.
+	* GitHub's documentation is pretty terrible for this. All you have to do is navigate to your repo that has the changes in it, select the "Pull Request" button and you can add the name/comments about your changes there.
 
 ### EXAMPLE
 


### PR DESCRIPTION
@alulsh and @pamtaro: Hopefully I found every spot to get rid of the "hack night" and "study group" labels (unless it's specifically a hack night). Definitely more work that could be done here to better reflect our current state(s).
